### PR TITLE
Fix handling string type responses

### DIFF
--- a/src/network.ts
+++ b/src/network.ts
@@ -13,6 +13,9 @@ export class NetworkException<T> {
 
 function parseResponse(res) {
   try {
+    if(typeof res === 'string' || res instanceof String)
+        return res;
+    
     return res ? JSON.parse(res) : null;
   } catch (err) {
     return null;


### PR DESCRIPTION
Currently response is not parsed and result is null when response is just a string